### PR TITLE
Fixes Issue #16 by including missing methods (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2019-10-31
+### Changed
+- Adds missing methods to ActiveRecord generator to fix issue #16.
+- Adds a missing manifest.js to Dummy application.
+- Fixes devise_error_messages! deprecation warning by using the new partial.
+- Fixes sqlite3.represent_boolean_as_integer deprecation warning in specs.
+
 ## [0.4.0] - 2019-08-22
 ### Added
 - Appraisal suite.

--- a/app/views/devise/credentials/refresh.html.erb
+++ b/app/views/devise/credentials/refresh.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_for(resource, as: resource_name, url: [:refresh, resource_name, :credential], html: { method: :put }) do |f| %>
 
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
     <div><%= f.label :email %><br />
     <%= f.text_field :email, disabled: :true%></div>

--- a/app/views/devise/tokens/show.html.erb
+++ b/app/views/devise/tokens/show.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_for(resource, as: resource_name, url: [resource_name, :token], html: { method: :put }) do |f| %>
 
-	<%= devise_error_messages! %>
+	<%= render "devise/shared/error_messages", resource: resource %>
 
 	<h3><%= I18n.t('enable_request', {scope: 'devise.two_factor.tokens'}) %></h3>
 

--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rails", ">= 4.1", "< 6.1"
 
-  gem.add_runtime_dependency 'devise', '~> 4.0'
+  gem.add_runtime_dependency 'devise', '~> 4.6'
   gem.add_runtime_dependency 'rotp', '~> 5.1'
   gem.add_runtime_dependency 'rqrcode', '~> 0.10.1'
   gem.add_runtime_dependency 'symmetric-encryption', '~> 4.3.0'

--- a/lib/devise-2fa/version.rb
+++ b/lib/devise-2fa/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module TwoFactor
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.4.1'.freeze
   end
 end

--- a/lib/generators/active_record/devise_two_factor_generator.rb
+++ b/lib/generators/active_record/devise_two_factor_generator.rb
@@ -27,6 +27,16 @@ module ActiveRecord
   validates :otp_recovery_secret, symmetric_encryption: true
 RUBY
       end
+
+      private
+
+      def model_exists?
+        File.exist?(File.join(destination_root, model_path))
+      end
+
+      def model_path
+        @model_path ||= File.join("app", "models", "#{file_path}.rb")
+      end
     end
   end
 end

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -17,5 +17,8 @@ require 'devise'
 module Dummy
   class Application < Rails::Application
     config.load_defaults 5.0
+    unless ENV['BUNDLE_GEMFILE'].include?('mongodb')
+      Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
+    end
   end
 end


### PR DESCRIPTION
* Fixes Issue #16 by including missing methods

This fixes the error which occurred when running rails g devise_two_factor User on a properly configured application.

* Adds missing manifest.js to Dummy application.

* Fixes devise_error_messages! deprecation, upgrades Devise to '~> 4.6'

* Fixes sqlite3.represent_boolean_as_integer deprecation warning.

* Upgrade version and changelong